### PR TITLE
fix: hash password before storing it

### DIFF
--- a/_server/registration/views.py
+++ b/_server/registration/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render, redirect
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, make_password
 from django.contrib.auth import login, authenticate, logout
 from django.http import JsonResponse
 
@@ -8,7 +8,8 @@ def sign_up(req):
     if req.method == "POST":
         user = User.objects.create_user(
             username=req.POST.get("email"),
-            password=req.POST.get("password"),
+            # Hashing is mandatory, as we use authenticate below
+            password=make_password(req.POST.get("password")),
             email=req.POST.get("email"),
             first_name=req.POST.get("first_name"),
             last_name=req.POST.get("last_name")


### PR DESCRIPTION
From my testing, Django does not automatically hash the password field of the User model. This will resolve that problem.

See Co-authorship in first commit for school email.